### PR TITLE
Add BC airports JSON dataset

### DIFF
--- a/bc_airports.json
+++ b/bc_airports.json
@@ -1,0 +1,4981 @@
+{
+  "CA-0016": {
+    "name": "Dog Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.626598,
+    "lon": -122.255997,
+    "elev": null
+  },
+  "CA-0024": {
+    "name": "Anderson Ranch Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.45000076293945,
+    "lon": -123.56666564941406,
+    "elev": null
+  },
+  "CA-0025": {
+    "name": "Anglemont Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.9684,
+    "lon": -119.166813,
+    "elev": null
+  },
+  "CA-0028": {
+    "name": "Sundance Guest Ranch \"C\" Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.66669845581055,
+    "lon": -121.26699829101562,
+    "elev": null
+  },
+  "CA-0035": {
+    "name": "Batnuni Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.38333511352539,
+    "lon": -124.13333129882812,
+    "elev": null
+  },
+  "CA-0038": {
+    "name": "Beatton River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.379861,
+    "lon": -121.411645,
+    "elev": null
+  },
+  "CA-0041": {
+    "name": "Beaver River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.971508,
+    "lon": -124.203272,
+    "elev": null
+  },
+  "CA-0042": {
+    "name": "Beaverdell Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.457246,
+    "lon": -119.088063,
+    "elev": 2638
+  },
+  "CA-0049": {
+    "name": "Big Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.726497,
+    "lon": -123.027134,
+    "elev": null
+  },
+  "CA-0057": {
+    "name": "Boston Bar Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.983334,
+    "lon": -121.5,
+    "elev": 1039
+  },
+  "CA-0067": {
+    "name": "Burrage Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.266666412353516,
+    "lon": -130.25,
+    "elev": null
+  },
+  "CA-0069": {
+    "name": "Knutsford Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.598031,
+    "lon": -120.30864,
+    "elev": null
+  },
+  "CA-0072": {
+    "name": "Cabin Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.269517,
+    "lon": -121.626025,
+    "elev": 2238
+  },
+  "CA-0087": {
+    "name": "Charlotte Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.153139,
+    "lon": -125.275156,
+    "elev": 3835
+  },
+  "CA-0089": {
+    "name": "Chilko Lake (Wilderness Ranch) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.665422,
+    "lon": -124.144478,
+    "elev": null
+  },
+  "CA-0090": {
+    "name": "Chipmunk Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.71666717529297,
+    "lon": -127.83333587646484,
+    "elev": null
+  },
+  "CA-0091": {
+    "name": "Chunamon Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.233333587646484,
+    "lon": -124.38333129882812,
+    "elev": null
+  },
+  "CA-0093": {
+    "name": "Clearwater Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.65739,
+    "lon": -120.070878,
+    "elev": 1512
+  },
+  "CA-0104": {
+    "name": "Crawfish Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.70000076293945,
+    "lon": -126.76667022705078,
+    "elev": null
+  },
+  "CA-0109": {
+    "name": "Cypre River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.257414,
+    "lon": -125.938897,
+    "elev": null
+  },
+  "CA-0119": {
+    "name": "Driftwood Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.81666564941406,
+    "lon": -126.41666412353516,
+    "elev": null
+  },
+  "CA-0122": {
+    "name": "Eaglenest Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.599998474121094,
+    "lon": -129.4166717529297,
+    "elev": null
+  },
+  "CA-0132": {
+    "name": "Finbow Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.266663,
+    "lon": -125.449997,
+    "elev": 2460
+  },
+  "CA-0136": {
+    "name": "Fort Nelson (Forestry) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.79999923706055,
+    "lon": -122.73332977294922,
+    "elev": null
+  },
+  "CA-0137": {
+    "name": "Mobil Sierra Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.834113,
+    "lon": -121.393175,
+    "elev": null
+  },
+  "CA-0138": {
+    "name": "Tompkins Mile 54 Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.309947,
+    "lon": -121.006106,
+    "elev": null
+  },
+  "CA-0141": {
+    "name": "Germansen Landing Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.767439,
+    "lon": -124.691757,
+    "elev": null
+  },
+  "CA-0147": {
+    "name": "Gold River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.81666564941406,
+    "lon": -126.06666564941406,
+    "elev": null
+  },
+  "CA-0152": {
+    "name": "Gun Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.897585,
+    "lon": -122.837966,
+    "elev": null
+  },
+  "CA-0172": {
+    "name": "Jedney Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.21666717529297,
+    "lon": -122.21666717529297,
+    "elev": null
+  },
+  "CA-0175": {
+    "name": "Johanson Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.599998474121094,
+    "lon": -126.19999694824219,
+    "elev": null
+  },
+  "CA-0189": {
+    "name": "Kimsquit Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.883175,
+    "lon": -127.089758,
+    "elev": 75
+  },
+  "CA-0193": {
+    "name": "Klappan River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.78333282470703,
+    "lon": -129.61666870117188,
+    "elev": null
+  },
+  "CA-0194": {
+    "name": "Kluakaz Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.11666488647461,
+    "lon": -128.6666717529297,
+    "elev": null
+  },
+  "CA-0195": {
+    "name": "Kluatanton Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.83333206176758,
+    "lon": -128.13333129882812,
+    "elev": null
+  },
+  "CA-0197": {
+    "name": "Kotcho Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.08333206176758,
+    "lon": -121.25,
+    "elev": null
+  },
+  "CA-0204": {
+    "name": "Lemoray Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.54999923706055,
+    "lon": -122.46666717529297,
+    "elev": null
+  },
+  "CA-0207": {
+    "name": "Liard River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.516666,
+    "lon": -126.366669,
+    "elev": null
+  },
+  "CA-0214": {
+    "name": "Lytton Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.245,
+    "lon": -121.5683,
+    "elev": 930
+  },
+  "CA-0219": {
+    "name": "Mahatta River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.44204,
+    "lon": -127.793312,
+    "elev": null
+  },
+  "CA-0222": {
+    "name": "Marilla Arifield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.661528,
+    "lon": -125.761926,
+    "elev": null
+  },
+  "CA-0227": {
+    "name": "Mesilinka River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.097896,
+    "lon": -124.40094,
+    "elev": 2231
+  },
+  "CA-0228": {
+    "name": "Mica Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.83333206176758,
+    "lon": -118.63333129882812,
+    "elev": null
+  },
+  "CA-0237": {
+    "name": "East Barriere Lake",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.2536697022,
+    "lon": -119.863629341,
+    "elev": 2070
+  },
+  "CA-0240": {
+    "name": "Moh Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.525439,
+    "lon": -125.053607,
+    "elev": null
+  },
+  "CA-0242": {
+    "name": "Moose Valley Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.733333587646484,
+    "lon": -126.6500015258789,
+    "elev": null
+  },
+  "CA-0243": {
+    "name": "Mosque Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.483333587646484,
+    "lon": -127.53333282470703,
+    "elev": null
+  },
+  "CA-0251": {
+    "name": "Muddy Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.195421,
+    "lon": -132.325988,
+    "elev": null
+  },
+  "CA-0260": {
+    "name": "Nimpo Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.320295,
+    "lon": -125.234047,
+    "elev": 3967
+  },
+  "CA-0276": {
+    "name": "Parson Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.083332,
+    "lon": -116.633331,
+    "elev": null
+  },
+  "CA-0292": {
+    "name": "Port Eliza Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.88333511352539,
+    "lon": -127.1500015258789,
+    "elev": null
+  },
+  "CA-0299": {
+    "name": "Prophet River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.966667,
+    "lon": -122.783333,
+    "elev": 1887
+  },
+  "CA-0302": {
+    "name": "Quatam River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.384574,
+    "lon": -124.935409,
+    "elev": null
+  },
+  "CA-0305": {
+    "name": "Raspberry Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.04999923706055,
+    "lon": -124.21666717529297,
+    "elev": null
+  },
+  "CA-0311": {
+    "name": "Riske Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.958652,
+    "lon": -122.508652,
+    "elev": 2999
+  },
+  "CA-0323": {
+    "name": "Private Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.46689987182617,
+    "lon": -127.7030029296875,
+    "elev": 1061
+  },
+  "CA-0324": {
+    "name": "Saltspring Island Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.766666412353516,
+    "lon": -123.46666717529297,
+    "elev": null
+  },
+  "CA-0329": {
+    "name": "Scar Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.179237,
+    "lon": -125.039177,
+    "elev": null
+  },
+  "CA-0330": {
+    "name": "Scud River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.28333282470703,
+    "lon": -131.8333282470703,
+    "elev": null
+  },
+  "CA-0336": {
+    "name": "Sheslay Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.266666412353516,
+    "lon": -131.78334045410156,
+    "elev": null
+  },
+  "CA-0337": {
+    "name": "Nass Camp Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.29069900512695,
+    "lon": -128.9969940185547,
+    "elev": null
+  },
+  "CA-0340": {
+    "name": "Sikanni Chief Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.08333206176758,
+    "lon": -122.5999984741211,
+    "elev": null
+  },
+  "CA-0345": {
+    "name": "Smith River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.900001525878906,
+    "lon": -126.43333435058594,
+    "elev": null
+  },
+  "CA-0357": {
+    "name": "Stave Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.467727,
+    "lon": -122.225691,
+    "elev": 352
+  },
+  "CA-0363": {
+    "name": "Stobart Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.472702,
+    "lon": -122.833614,
+    "elev": null
+  },
+  "CA-0365": {
+    "name": "Strandberg Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.001957,
+    "lon": -124.236917,
+    "elev": 2260
+  },
+  "CA-0369": {
+    "name": "Sturdee Valley Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.20000076293945,
+    "lon": -127.08333587646484,
+    "elev": null
+  },
+  "CA-0377": {
+    "name": "Tatla Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.915606,
+    "lon": -124.598401,
+    "elev": null
+  },
+  "CA-0379": {
+    "name": "Tetachuck Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.266666412353516,
+    "lon": -126.06666564941406,
+    "elev": null
+  },
+  "CA-0390": {
+    "name": "Twin Lakes Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.564534,
+    "lon": -123.824673,
+    "elev": null
+  },
+  "CA-0395": {
+    "name": "Valemount Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.865732,
+    "lon": -119.295711,
+    "elev": 2575
+  },
+  "CA-0396": {
+    "name": "Burnaby (Terminal) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.2691976954,
+    "lon": -122.933339775,
+    "elev": null
+  },
+  "CA-0415": {
+    "name": "Woss Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.215459,
+    "lon": -126.619756,
+    "elev": 420
+  },
+  "CA-0422": {
+    "name": "Yoyo Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.9258,
+    "lon": -121.473201,
+    "elev": 1950
+  },
+  "CA-0424": {
+    "name": "Witwer Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.53519821166992,
+    "lon": -127.86599731445312,
+    "elev": 1070
+  },
+  "CA-0425": {
+    "name": "Seeley Lake Field",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.193001,
+    "lon": -127.712997,
+    "elev": 987
+  },
+  "CA-0446": {
+    "name": "Stuart Island Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.409447,
+    "lon": -125.131617,
+    "elev": 360
+  },
+  "CA-0450": {
+    "name": "Monte Creek Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.648263182,
+    "lon": -119.90032196,
+    "elev": null
+  },
+  "CA-0451": {
+    "name": "Prichard Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.659473079099996,
+    "lon": -119.793720245,
+    "elev": null
+  },
+  "CA-0453": {
+    "name": "Sheridan Lake Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.4954922213,
+    "lon": -120.835790634,
+    "elev": null
+  },
+  "CA-0475": {
+    "name": "Dugan Lake Air Strip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.1977699021,
+    "lon": -121.957587004,
+    "elev": null
+  },
+  "CA-0476": {
+    "name": "Williams Lake / Lee Todd Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.165890651199994,
+    "lon": -122.20654428,
+    "elev": null
+  },
+  "CA-0477": {
+    "name": "Williams Lake / Clusko Logging",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.165857747,
+    "lon": -122.162486315,
+    "elev": null
+  },
+  "CA-0478": {
+    "name": "Williams Lake / Highland Helicopters",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.140471539,
+    "lon": -122.158881426,
+    "elev": null
+  },
+  "CA-0479": {
+    "name": "Williams Lake / Wayne Peterson Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.1237896659,
+    "lon": -122.107565403,
+    "elev": null
+  },
+  "CA-0480": {
+    "name": "Williams Lake / Pioneer Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.110247928700005,
+    "lon": -122.134366035,
+    "elev": null
+  },
+  "CA-0496": {
+    "name": "Quasar Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.883618,
+    "lon": -120.648594,
+    "elev": 3691
+  },
+  "CA-0499": {
+    "name": "Sumas Municipal Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.038515,
+    "lon": -122.130675,
+    "elev": null
+  },
+  "CA-0517": {
+    "name": "Hastings Field Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.781844,
+    "lon": -123.281611,
+    "elev": 190,
+    "Freq": 123.2
+  },
+  "CA-0538": {
+    "name": "Pretty Estates Resort Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.252372,
+    "lon": -121.945846,
+    "elev": 62
+  },
+  "CA-0539": {
+    "name": "Stuart Island Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.3629,
+    "lon": -125.1385,
+    "elev": null
+  },
+  "CA-0540": {
+    "name": "Bella Coola Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.3774,
+    "lon": -126.7954,
+    "elev": null
+  },
+  "CA-0541": {
+    "name": "Nimpkish Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.33,
+    "lon": -126.93,
+    "elev": 82
+  },
+  "CA-0542": {
+    "name": "Nakusp Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.234,
+    "lon": -117.8,
+    "elev": 1448
+  },
+  "CA-0543": {
+    "name": "Winter Harbour Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.5117,
+    "lon": -128.0284,
+    "elev": 0
+  },
+  "CA-0544": {
+    "name": "Morfee Lakes Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.35,
+    "lon": -123.08,
+    "elev": 2365
+  },
+  "CA-0545": {
+    "name": "Takla Narrows Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.1635,
+    "lon": -125.7133,
+    "elev": 2257
+  },
+  "CA-0546": {
+    "name": "Dease Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.459,
+    "lon": -130.038,
+    "elev": 2470
+  },
+  "CA-0547": {
+    "name": "Invermere Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.49,
+    "lon": -116.01,
+    "elev": 2618
+  },
+  "CA-0548": {
+    "name": "North Cariboo Air Park",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.008098602295,
+    "lon": -123.02300262451,
+    "elev": 2500
+  },
+  "CA-0566": {
+    "name": "Triple Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.294727,
+    "lon": -130.880179,
+    "elev": 40
+  },
+  "CA-0579": {
+    "name": "Amphitrite Point Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.9224,
+    "lon": -125.541601,
+    "elev": 73
+  },
+  "CA-0580": {
+    "name": "Egg Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.249701,
+    "lon": -127.8364,
+    "elev": 42
+  },
+  "CA-0581": {
+    "name": "Green Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.56854,
+    "lon": -130.70648,
+    "elev": 3
+  },
+  "CA-0582": {
+    "name": "Bamfield Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.8206,
+    "lon": -125.1193,
+    "elev": 232
+  },
+  "CA-0583": {
+    "name": "Scarlett Point Lighthouse Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.8609,
+    "lon": -127.6126,
+    "elev": 31
+  },
+  "CA-0585": {
+    "name": "Race Rocks Light Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.298504,
+    "lon": -123.5322,
+    "elev": 10
+  },
+  "CA-0596": {
+    "name": "Machmell Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.6561,
+    "lon": -126.681703,
+    "elev": 40
+  },
+  "CA-0603": {
+    "name": "Homathko River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.9501,
+    "lon": -124.8848,
+    "elev": 30
+  },
+  "CA-0604": {
+    "name": "Stuart Lake Hospital Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.440705,
+    "lon": -124.2424,
+    "elev": 2362
+  },
+  "CA-0612": {
+    "name": "Chrome Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.471829,
+    "lon": -124.684468,
+    "elev": 48
+  },
+  "CA-0621": {
+    "name": "Cape Scott Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.7819,
+    "lon": -128.427504,
+    "elev": 207
+  },
+  "CA-0630": {
+    "name": "Sisters Islets Lighthouse Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.486989,
+    "lon": -124.435062,
+    "elev": 12
+  },
+  "CA-0634": {
+    "name": "Ethelda Bay Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.057,
+    "lon": -129.677008,
+    "elev": 0
+  },
+  "CA-0636": {
+    "name": "Active Pass Lighthouse Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.8734,
+    "lon": -123.2914,
+    "elev": 24
+  },
+  "CA-0639": {
+    "name": "Alexis Creek Ranch Private Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.063197,
+    "lon": -123.258464,
+    "elev": 2300
+  },
+  "CA-0640": {
+    "name": "Stuart Lake Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.450003,
+    "lon": -124.31,
+    "elev": 2240
+  },
+  "CA-0641": {
+    "name": "Kemano Bay Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.480001,
+    "lon": -128.13,
+    "elev": 0
+  },
+  "CA-0642": {
+    "name": "Ivory Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.271104,
+    "lon": -128.405304,
+    "elev": 14
+  },
+  "CA-0645": {
+    "name": "Ethelda Bay Coast Guard Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.0536,
+    "lon": -129.680003,
+    "elev": 33
+  },
+  "CA-0646": {
+    "name": "Selkirk Mountain Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.010905,
+    "lon": -118.209501,
+    "elev": 1559
+  },
+  "CA-0647": {
+    "name": "Discovery Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.4248,
+    "lon": -123.225802,
+    "elev": 63
+  },
+  "CA-0658": {
+    "name": "Squamish Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.68,
+    "lon": -123.165001,
+    "elev": 0
+  },
+  "CA-0659": {
+    "name": "Yahk Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.109,
+    "lon": -116.0598,
+    "elev": 2870
+  },
+  "CA-0660": {
+    "name": "Bonilla Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.492902,
+    "lon": -130.6353,
+    "elev": 13
+  },
+  "CA-0661": {
+    "name": "Addenbroke Island Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.6045,
+    "lon": -127.863602,
+    "elev": 28
+  },
+  "CA-0662": {
+    "name": "Tsayta Lake Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.450345,
+    "lon": -125.457764,
+    "elev": 2887
+  },
+  "CA-0664": {
+    "name": "Heli-Delta Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.1739,
+    "lon": -122.951,
+    "elev": 40
+  },
+  "CA-0674": {
+    "name": "Bowron Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.255704,
+    "lon": -121.42034,
+    "elev": 3000
+  },
+  "CA-0677": {
+    "name": "Intergalactic Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.020113,
+    "lon": -122.732826,
+    "elev": 10
+  },
+  "CA-0707": {
+    "name": "Petitot Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.719703,
+    "lon": -121.844599,
+    "elev": 1558
+  },
+  "CA-0724": {
+    "name": "Canadian Coast Guard Base Sea Island Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.181066,
+    "lon": -123.184119,
+    "elev": null
+  },
+  "CA-0725": {
+    "name": "Vancouver (HMCS Discovery) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.29437,
+    "lon": -123.12346,
+    "elev": null
+  },
+  "CA-0726": {
+    "name": "Belcarra (Jug Island Trail) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.323835,
+    "lon": -122.920291,
+    "elev": null
+  },
+  "CA-0727": {
+    "name": "Squamish General Hospital Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.69705,
+    "lon": -123.1419,
+    "elev": null
+  },
+  "CA-0728": {
+    "name": "Stawamus Chief Emergency Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.67982,
+    "lon": -123.14498,
+    "elev": null
+  },
+  "CA-0729": {
+    "name": "Squamish Terminals Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.68392,
+    "lon": -123.17314,
+    "elev": null
+  },
+  "CA-0730": {
+    "name": "Squamish (Woodfibre) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.66441,
+    "lon": -123.25656,
+    "elev": null
+  },
+  "CA-0732": {
+    "name": "Poise Cove Waterdrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.49062,
+    "lon": -123.75212,
+    "elev": null
+  },
+  "CA-0740": {
+    "name": "Lax Kw'alaams Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.55985,
+    "lon": -130.42957,
+    "elev": null
+  },
+  "CA-0741": {
+    "name": "Kitkatla Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.79515,
+    "lon": -130.42563,
+    "elev": null
+  },
+  "CA-0742": {
+    "name": "Hartley Bay Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.4253,
+    "lon": -129.25036,
+    "elev": null
+  },
+  "CA-0746": {
+    "name": "Eddontenajon Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.808,
+    "lon": -129.97,
+    "elev": 2710
+  },
+  "CA-0747": {
+    "name": "CFB Esquimalt - Colwood Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.44815,
+    "lon": -123.45418,
+    "elev": null
+  },
+  "CA-0763": {
+    "name": "Egmont Waterdrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.75086,
+    "lon": -123.92782,
+    "elev": null
+  },
+  "CA-0764": {
+    "name": "Halfmoon Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.51056,
+    "lon": -123.91295,
+    "elev": null
+  },
+  "CA-0765": {
+    "name": "Earls Cove Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.75353,
+    "lon": -124.00871,
+    "elev": null
+  },
+  "CA-0766": {
+    "name": "Saltery Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.78122,
+    "lon": -124.17746,
+    "elev": null
+  },
+  "CA-0767": {
+    "name": "Purcell Heli Skiing Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.30236,
+    "lon": -116.93991,
+    "elev": 3084
+  },
+  "CA-0768": {
+    "name": "Thunder Hill Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.18887,
+    "lon": -115.85229,
+    "elev": 2792
+  },
+  "CA-0769": {
+    "name": "Canal Flats Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.16308,
+    "lon": -115.82857,
+    "elev": 2667
+  },
+  "CA-0770": {
+    "name": "Elkford Health Centre Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.020642,
+    "lon": -114.917336,
+    "elev": 4131
+  },
+  "CA-0772": {
+    "name": "Shuswap (Skwlax Field) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.878669,
+    "lon": -119.590816,
+    "elev": 1170,
+    "Freq": 123.2
+  },
+  "CA-0784": {
+    "name": "Kleena Kleene (Chilanko Lodge) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.957371,
+    "lon": -124.885969,
+    "elev": 3032
+  },
+  "CA-0785": {
+    "name": "Long Harbour Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.858482,
+    "lon": -123.47487,
+    "elev": 50
+  },
+  "CA-0788": {
+    "name": "Rivers Inlet Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.683639,
+    "lon": -127.185741,
+    "elev": 72
+  },
+  "CA-0789": {
+    "name": "Great Bear Lodge Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.374089,
+    "lon": -127.123828,
+    "elev": null
+  },
+  "CA-0792": {
+    "name": "Kitchner Lake Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.052681,
+    "lon": -127.43454,
+    "elev": 4321
+  },
+  "CA-0793": {
+    "name": "Clyak River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.885622,
+    "lon": -127.353264,
+    "elev": 30
+  },
+  "CA-0794": {
+    "name": "Butedale Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.159821,
+    "lon": -128.694692,
+    "elev": 6
+  },
+  "CA-0795": {
+    "name": "Metlakatla Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.336063,
+    "lon": -130.442047,
+    "elev": 9
+  },
+  "CA-0801": {
+    "name": "Kamloops RCMP Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.655236,
+    "lon": -120.366222,
+    "elev": null
+  },
+  "CA-0802": {
+    "name": "Kamloops RCMP Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.655236,
+    "lon": -120.366222,
+    "elev": null
+  },
+  "CA-0803": {
+    "name": "Kamloops RCMP Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.655236,
+    "lon": -120.366222,
+    "elev": null
+  },
+  "CA-0810": {
+    "name": "Kamloops Model Airplane Society Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.840558,
+    "lon": -120.268223,
+    "elev": null
+  },
+  "CA-0811": {
+    "name": "Michell Airpark",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.5658,
+    "lon": -123.391178,
+    "elev": null
+  },
+  "CA-0812": {
+    "name": "One Hundred Mile Model Flyers",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.619397,
+    "lon": -121.315198,
+    "elev": null
+  },
+  "CA-0813": {
+    "name": "Kelowna Ogopogo Radio Controllers",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.040422,
+    "lon": -119.394365,
+    "elev": null
+  },
+  "CA-0819": {
+    "name": "Norbury Lakes Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.53903,
+    "lon": -115.47411,
+    "elev": 2749
+  },
+  "CA-0820": {
+    "name": "Hahas Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.72681,
+    "lon": -115.78302,
+    "elev": 2986
+  },
+  "CA-0821": {
+    "name": "Wolf Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.82296,
+    "lon": -115.73124,
+    "elev": 2730
+  },
+  "CA-0837": {
+    "name": "Shuswap Lake Estates Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.86834,
+    "lon": -119.37353,
+    "elev": 1539
+  },
+  "CA-0838": {
+    "name": "Gaglardi Tower (Royal Inland Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.670082,
+    "lon": -120.333821,
+    "elev": null
+  },
+  "CA-0841": {
+    "name": "Hakai Passage Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.669733,
+    "lon": -128.08181,
+    "elev": 0
+  },
+  "CA-0846": {
+    "name": "Swan Lake Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.32,
+    "lon": -119.257,
+    "elev": 1280
+  },
+  "CA-0847": {
+    "name": "Minette Bay Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.02,
+    "lon": -128.63,
+    "elev": 1450
+  },
+  "CA-0856": {
+    "name": "Twin Lakes Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.22183,
+    "lon": -121.75476,
+    "elev": 3369
+  },
+  "CA-0857": {
+    "name": "Caribou Canim Ranch Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.88313,
+    "lon": -120.61608,
+    "elev": 2569
+  },
+  "CA-0880": {
+    "name": "Elkford Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.00702,
+    "lon": -114.923179,
+    "elev": 4298
+  },
+  "CA-0882": {
+    "name": "Tabor Lake Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.91565,
+    "lon": -122.54085,
+    "elev": 2290
+  },
+  "CA-0883": {
+    "name": "Holberg Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.645,
+    "lon": -127.99,
+    "elev": null
+  },
+  "CA-0886": {
+    "name": "Augustine Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.36499,
+    "lon": -122.63596,
+    "elev": 2421
+  },
+  "CA-0914": {
+    "name": "Nimpo Lake Resort Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.37475,
+    "lon": -125.23533,
+    "elev": 3743
+  },
+  "CA-0923": {
+    "name": "Montague Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.89225,
+    "lon": -123.39215,
+    "elev": null
+  },
+  "CA-0930": {
+    "name": "Clinton Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.1534,
+    "lon": -121.52784,
+    "elev": 3796
+  },
+  "CA-0933": {
+    "name": "Ojay Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.671647,
+    "lon": -120.342214,
+    "elev": 3547
+  },
+  "CA-0935": {
+    "name": "King Eddys Landing Field",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.21596,
+    "lon": -119.17362,
+    "elev": 1710
+  },
+  "CA-0936": {
+    "name": "Castle Rock Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.51069,
+    "lon": -122.47769,
+    "elev": 2113
+  },
+  "CA-0938": {
+    "name": "Nazko Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.09207,
+    "lon": -123.56459,
+    "elev": 2700
+  },
+  "CA-0945": {
+    "name": "RCAF Station Jericho Beach / Vancouver Air Station",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.271669,
+    "lon": -123.197894,
+    "elev": null
+  },
+  "CA-0962": {
+    "name": "Mile 62 1/2 Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.38144,
+    "lon": -121.12662,
+    "elev": 2741
+  },
+  "CA-0976": {
+    "name": "Rotor Maxx Support Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.31296,
+    "lon": -124.36237,
+    "elev": 236
+  },
+  "CA-0977": {
+    "name": "CMH Bugaboos Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.89842,
+    "lon": -116.35744,
+    "elev": 2644
+  },
+  "CA-0978": {
+    "name": "CMH Bobbie Burns Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.05952,
+    "lon": -116.65393,
+    "elev": 2635
+  },
+  "CA-0979": {
+    "name": "Sakinaw Lake South Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.654,
+    "lon": -124.0638,
+    "elev": 27
+  },
+  "CA-1001": {
+    "name": "Tsacha Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.019365,
+    "lon": -124.843891,
+    "elev": 3450
+  },
+  "CA-1002": {
+    "name": "Kamloops (BC Hydro) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.666766,
+    "lon": -120.370989,
+    "elev": 1770
+  },
+  "CA-1003": {
+    "name": "Crawford Bay Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.668111,
+    "lon": -116.818,
+    "elev": 1760
+  },
+  "CA-1004": {
+    "name": "Barkerville Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.0881,
+    "lon": -121.514999,
+    "elev": 4060
+  },
+  "CA-1005": {
+    "name": "Hope (Fraser Canyon Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.376911,
+    "lon": -121.423465,
+    "elev": 114
+  },
+  "CA-1006": {
+    "name": "Gang Ranch Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.551862,
+    "lon": -122.327932,
+    "elev": 2150
+  },
+  "CA-1007": {
+    "name": "Campbell River (West Coast) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.046398,
+    "lon": -125.252996,
+    "elev": 7
+  },
+  "CA-1008": {
+    "name": "Tipella Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.743099,
+    "lon": -122.163002,
+    "elev": 55
+  },
+  "CA-1009": {
+    "name": "Takla Narrows Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.163549,
+    "lon": -125.706124,
+    "elev": 2380
+  },
+  "CA-1010": {
+    "name": "Telegraph Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.914369,
+    "lon": -131.125592,
+    "elev": 1100
+  },
+  "CA-1011": {
+    "name": "Quilchena Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.162154,
+    "lon": -120.506935,
+    "elev": 2100
+  },
+  "CA-1012": {
+    "name": "Mission (Memorial Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.1362047065,
+    "lon": -122.331220061,
+    "elev": 174
+  },
+  "CA-1013": {
+    "name": "Terrace / BC Hydro Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.5192008823,
+    "lon": -128.628015518,
+    "elev": 195
+  },
+  "CA-1038": {
+    "name": "Fort Nelson (Mile 301) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.805852,
+    "lon": -122.728829,
+    "elev": 1400
+  },
+  "CA-1042": {
+    "name": "Vancouver (Vancouver Film Studios) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.260877,
+    "lon": -123.028082,
+    "elev": 50
+  },
+  "CA-1045": {
+    "name": "Golden (Canadian Helicopters) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.304475,
+    "lon": -116.983535,
+    "elev": 2575
+  },
+  "CA-1046": {
+    "name": "Stewart (Health Centre) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.9402999878,
+    "lon": -129.990997314,
+    "elev": 26
+  },
+  "CA-1048": {
+    "name": "Aldergrove (Hicks) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.108781,
+    "lon": -122.480052,
+    "elev": 300
+  },
+  "CA-1096": {
+    "name": "King George Airpark",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.093248,
+    "lon": -122.822493,
+    "elev": 5
+  },
+  "CA-1114": {
+    "name": "Leo Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.119853,
+    "lon": -125.614054,
+    "elev": 2360
+  },
+  "CA-1115": {
+    "name": "Bronson Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.681098938,
+    "lon": -131.087005615,
+    "elev": 396
+  },
+  "CA-1116": {
+    "name": "Salmo Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.166698455811,
+    "lon": -117.26699829102,
+    "elev": null
+  },
+  "CA-1118": {
+    "name": "Alice Arm/Silver City Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.466702,
+    "lon": -129.483002,
+    "elev": null
+  },
+  "CA-1122": {
+    "name": "Dawson Creek Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.744274,
+    "lon": -120.182942,
+    "elev": 2145
+  },
+  "CA-1124": {
+    "name": "Finlay Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.98,
+    "lon": -123.78,
+    "elev": 2205
+  },
+  "CA-1125": {
+    "name": "Fort Grahame Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.5275,
+    "lon": -124.473,
+    "elev": 2205
+  },
+  "CA-1132": {
+    "name": "Mission Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.127765,
+    "lon": -122.301961,
+    "elev": 10
+  },
+  "CA-1136": {
+    "name": "Penticton Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.45003,
+    "lon": -119.599998,
+    "elev": 1108
+  },
+  "CA-1137": {
+    "name": "Port Alice/Jeune Landing Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.423233,
+    "lon": -127.486232,
+    "elev": null
+  },
+  "CA-1138": {
+    "name": "Port Simpson Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.5667,
+    "lon": -130.432999,
+    "elev": 0
+  },
+  "CA-1140": {
+    "name": "Rykerts Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.004482,
+    "lon": -116.503057,
+    "elev": null
+  },
+  "CA-1143": {
+    "name": "Vanderhoof (District) Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.0206,
+    "lon": -123.995001,
+    "elev": 2050
+  },
+  "CA-1144": {
+    "name": "Williams Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.116699,
+    "lon": -122.099998,
+    "elev": 1859
+  },
+  "CA-1146": {
+    "name": "Otway Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.951668,
+    "lon": -122.831665,
+    "elev": 1954
+  },
+  "CA-1150": {
+    "name": "Victoria (BC Hydro) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.490004,
+    "lon": -123.390292,
+    "elev": 40
+  },
+  "CA-1154": {
+    "name": "Tasu Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.7630555556,
+    "lon": -132.04,
+    "elev": 0
+  },
+  "CA-1161": {
+    "name": "Kahntah Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.041502,
+    "lon": -120.9092,
+    "elev": 1630
+  },
+  "CA-1162": {
+    "name": "Devon Camp Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.3186,
+    "lon": -120.2769,
+    "elev": 1510
+  },
+  "CA-1172": {
+    "name": "Penfold Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.767722,
+    "lon": -120.749134,
+    "elev": 3642
+  },
+  "CA-1179": {
+    "name": "Cassiar Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.277137,
+    "lon": -129.805044,
+    "elev": 3618
+  },
+  "CA-CAB5": {
+    "name": "Abbotsford (Regional Hospital & Cancer Centre) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.0361500085,
+    "lon": -122.314048558,
+    "elev": 287
+  },
+  "CAA5": {
+    "name": "Zeballos Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.9778,
+    "lon": -126.8445,
+    "elev": 0
+  },
+  "CAA6": {
+    "name": "Smithers (Canadian) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.772295,
+    "lon": -127.141599,
+    "elev": 1600
+  },
+  "CAA7": {
+    "name": "Gilford Island/Echo Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.766701,
+    "lon": -126.483002,
+    "elev": null
+  },
+  "CAA8": {
+    "name": "Invermere Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.521502,
+    "lon": -116.005775,
+    "elev": 2820,
+    "Freq": 123.2
+  },
+  "CAA9": {
+    "name": "Port Alberni/Sproat Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.2891524507,
+    "lon": -124.937746525,
+    "elev": 95
+  },
+  "CAB3": {
+    "name": "Bedwell Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.75,
+    "lon": -123.233001709,
+    "elev": 0
+  },
+  "CAB4": {
+    "name": "Tofino Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.155,
+    "lon": -125.91,
+    "elev": null
+  },
+  "CAB7": {
+    "name": "Kelowna (Alpine) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.863872,
+    "lon": -119.568517,
+    "elev": 1640
+  },
+  "CAC8": {
+    "name": "Nanaimo Harbour Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.169813,
+    "lon": -123.933845,
+    "elev": null
+  },
+  "CAC9": {
+    "name": "Stewart Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.916698,
+    "lon": -130.0,
+    "elev": null
+  },
+  "CAD4": {
+    "name": "Trail Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.055599,
+    "lon": -117.609001,
+    "elev": 1427,
+    "Freq": 123.2
+  },
+  "CAD5": {
+    "name": "Merritt Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.122504,
+    "lon": -120.745368,
+    "elev": 2080,
+    "Freq": 123.2
+  },
+  "CAD6": {
+    "name": "Atlin Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.5666999817,
+    "lon": -133.716995239,
+    "elev": 2190
+  },
+  "CAD7": {
+    "name": "Gilford Island/Health Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.7000007629,
+    "lon": -126.599998474,
+    "elev": 0
+  },
+  "CAD8": {
+    "name": "Nelson Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.5,
+    "lon": -117.300003052,
+    "elev": 1740
+  },
+  "CAE2": {
+    "name": "Cranbrook (East Kootenay Regional Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.51250076293945,
+    "lon": -115.75,
+    "elev": 3050
+  },
+  "CAE3": {
+    "name": "Campbell River Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.049999,
+    "lon": -125.25,
+    "elev": null
+  },
+  "CAE5": {
+    "name": "Whistler/Green Lake Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.1436004639,
+    "lon": -122.948997498,
+    "elev": 2100
+  },
+  "CAE7": {
+    "name": "Harrison Hot Springs Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.3048530057,
+    "lon": -121.785936356,
+    "elev": 34
+  },
+  "CAE9": {
+    "name": "Bamfield Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.835967,
+    "lon": -125.137453,
+    "elev": null
+  },
+  "CAF4": {
+    "name": "Tsuniah Lake Lodge Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.526371,
+    "lon": -124.163961,
+    "elev": 4000
+  },
+  "CAF6": {
+    "name": "Big Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.3923,
+    "lon": -125.1372,
+    "elev": null
+  },
+  "CAF8": {
+    "name": "Nimpo Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.327,
+    "lon": -125.145,
+    "elev": 3665
+  },
+  "CAG3": {
+    "name": "Chilko Lake (Tsylos Park Lodge) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.625797,
+    "lon": -124.144478,
+    "elev": 3850
+  },
+  "CAG6": {
+    "name": "Blind Channel Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.416698,
+    "lon": -125.5,
+    "elev": 0
+  },
+  "CAG8": {
+    "name": "Pender Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.623785,
+    "lon": -124.024884,
+    "elev": null
+  },
+  "CAG9": {
+    "name": "Surge Narrows Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.219679,
+    "lon": -125.125596,
+    "elev": null
+  },
+  "CAH2": {
+    "name": "Ocean Falls Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.3666992188,
+    "lon": -127.717002869,
+    "elev": 0
+  },
+  "CAH3": {
+    "name": "Courtenay Airpark",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.679237,
+    "lon": -124.98064,
+    "elev": 26,
+    "Freq": 123.35
+  },
+  "CAH4": {
+    "name": "Valemount Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.852736,
+    "lon": -119.336266,
+    "elev": 2615,
+    "Freq": 123.2
+  },
+  "CAH7": {
+    "name": "Kamloops Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.698499,
+    "lon": -120.431862,
+    "elev": 1129
+  },
+  "CAH9": {
+    "name": "Telegraph Creek Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.9071,
+    "lon": -131.18946,
+    "elev": 1129
+  },
+  "CAJ3": {
+    "name": "Creston Valley Regional Airport - Art Sutcliffe Field",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.03689956665,
+    "lon": -116.49800109863,
+    "elev": 2070,
+    "Freq": 122.8
+  },
+  "CAJ4": {
+    "name": "Anahim Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.451501,
+    "lon": -125.303776,
+    "elev": 3635,
+    "Freq": 122.8
+  },
+  "CAJ8": {
+    "name": "Pitt Meadows Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.209215,
+    "lon": -122.709646,
+    "elev": 6
+  },
+  "CAJ9": {
+    "name": "Fort Ware Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.427857,
+    "lon": -125.648189,
+    "elev": 2450
+  },
+  "CAK3": {
+    "name": "Delta Heritage Air Park",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.0774,
+    "lon": -122.941002,
+    "elev": 10,
+    "Freq": 118.1
+  },
+  "CAK6": {
+    "name": "Camp Cordero Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.446694,
+    "lon": -125.453785,
+    "elev": 0
+  },
+  "CAK7": {
+    "name": "Vancouver (Children & Women's Health Centre) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.2438419064,
+    "lon": -123.127095848,
+    "elev": 225
+  },
+  "CAL2": {
+    "name": "Arrow Lakes Hospital Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.238378,
+    "lon": -117.795043,
+    "elev": 1515
+  },
+  "CAL3": {
+    "name": "Douglas Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.1654600485,
+    "lon": -120.171273351,
+    "elev": 2770,
+    "Freq": 123.2
+  },
+  "CAL7": {
+    "name": "Ganges (Lady Minto / Gulf Islands Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.862529,
+    "lon": -123.508717,
+    "elev": 148
+  },
+  "CAL9": {
+    "name": "Tahsis Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.916698455799995,
+    "lon": -126.666999817,
+    "elev": 0
+  },
+  "CAM3": {
+    "name": "Duncan Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.754534,
+    "lon": -123.709702,
+    "elev": 300,
+    "Freq": 122.8
+  },
+  "CAM5": {
+    "name": "Houston Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.440299,
+    "lon": -126.780023,
+    "elev": 2150,
+    "Freq": 123.2
+  },
+  "CAM8": {
+    "name": "Port McNeill Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.592231,
+    "lon": -127.088385,
+    "elev": null
+  },
+  "CAM9": {
+    "name": "Vancouver International Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.177047,
+    "lon": -123.168154,
+    "elev": 0
+  },
+  "CAN3": {
+    "name": "Ucluelet Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.950003,
+    "lon": -125.550005,
+    "elev": null
+  },
+  "CAN6": {
+    "name": "Prince Rupert/Digby Island Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.313646,
+    "lon": -130.405058,
+    "elev": 0
+  },
+  "CAP3": {
+    "name": "Sechelt-Gibsons Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.460601806599996,
+    "lon": -123.71900177,
+    "elev": 340
+  },
+  "CAP5": {
+    "name": "Victoria Airport Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.653892,
+    "lon": -123.450451,
+    "elev": null
+  },
+  "CAP6": {
+    "name": "Ingenika Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.790599823,
+    "lon": -124.897003174,
+    "elev": 2230
+  },
+  "CAP7": {
+    "name": "Kitkatla Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.7999992371,
+    "lon": -130.432998657,
+    "elev": null
+  },
+  "CAP8": {
+    "name": "Port Washington Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.812,
+    "lon": -123.321,
+    "elev": null
+  },
+  "CAQ3": {
+    "name": "Coal Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.597378,
+    "lon": -127.57865,
+    "elev": 0
+  },
+  "CAQ4": {
+    "name": "Springhouse Airpark",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.954881,
+    "lon": -122.140045,
+    "elev": 3250
+  },
+  "CAQ5": {
+    "name": "Nakusp Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.26639938354492,
+    "lon": -117.81300354003906,
+    "elev": 1689,
+    "Freq": 123.2
+  },
+  "CAQ6": {
+    "name": "Queen Charlotte City Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.25282,
+    "lon": -132.074214,
+    "elev": null
+  },
+  "CAQ8": {
+    "name": "Powell Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.887335,
+    "lon": -124.53372,
+    "elev": 174
+  },
+  "CAR7": {
+    "name": "Kyuquot Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.02803,
+    "lon": -127.374427,
+    "elev": null
+  },
+  "CAR9": {
+    "name": "Bella Bella/Waglisla Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.166698,
+    "lon": -128.132994,
+    "elev": null
+  },
+  "CAS2": {
+    "name": "Moose Lake Lodge Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.073803,
+    "lon": -125.408358,
+    "elev": 3500
+  },
+  "CAS4": {
+    "name": "Fort Langley Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.166698,
+    "lon": -122.532997,
+    "elev": 10
+  },
+  "CAS5": {
+    "name": "Aerosmith Heli Service Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.3074,
+    "lon": -124.413302,
+    "elev": 282
+  },
+  "CAT3": {
+    "name": "Nanaimo/Long Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.209538,
+    "lon": -124.008982,
+    "elev": 390
+  },
+  "CAT4": {
+    "name": "Qualicum Beach Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.337456,
+    "lon": -124.393086,
+    "elev": 191,
+    "Freq": 122.8
+  },
+  "CAT5": {
+    "name": "Port McNeill Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.57348,
+    "lon": -127.027702,
+    "elev": 225
+  },
+  "CAT6": {
+    "name": "Campbell River (Campbell River & District General Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.008556,
+    "lon": -125.242845,
+    "elev": 228
+  },
+  "CAT7": {
+    "name": "Lasqueti Island/False Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.5,
+    "lon": -124.349998,
+    "elev": null
+  },
+  "CAU3": {
+    "name": "Oliver Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.173301696777344,
+    "lon": -119.5510025024414,
+    "elev": 1015,
+    "Freq": 122.8
+  },
+  "CAU4": {
+    "name": "Vanderhoof Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.051607,
+    "lon": -124.010804,
+    "elev": 2225,
+    "Freq": 122.8
+  },
+  "CAU6": {
+    "name": "Gold River Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.679217,
+    "lon": -126.116203,
+    "elev": 0
+  },
+  "CAU8": {
+    "name": "Rivers Inlet Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.683985,
+    "lon": -127.264044,
+    "elev": null
+  },
+  "CAV3": {
+    "name": "One Hundred Mile House Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.64250183105469,
+    "lon": -121.30699920654297,
+    "elev": 3055
+  },
+  "CAV4": {
+    "name": "McBride Airport/Charlie Leake Field",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.314999,
+    "lon": -120.170998,
+    "elev": 2350
+  },
+  "CAV5": {
+    "name": "Sullivan Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.885359,
+    "lon": -126.831069,
+    "elev": null
+  },
+  "CAV7": {
+    "name": "Mansons Landing Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.07137,
+    "lon": -124.98362,
+    "elev": null
+  },
+  "CAV8": {
+    "name": "Shawnigan Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.633301,
+    "lon": -123.633003,
+    "elev": 380
+  },
+  "CAW3": {
+    "name": "Scum Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.795375,
+    "lon": -123.5816,
+    "elev": 3950
+  },
+  "CAW4": {
+    "name": "Whistler (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.120253,
+    "lon": -122.954679,
+    "elev": 2182
+  },
+  "CAW5": {
+    "name": "Port Hardy Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.716702,
+    "lon": -127.483002,
+    "elev": null
+  },
+  "CAW6": {
+    "name": "Fort Ware Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.4236,
+    "lon": -125.6442,
+    "elev": 2480
+  },
+  "CAW7": {
+    "name": "Mayne Island Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.852241,
+    "lon": -123.301982,
+    "elev": null
+  },
+  "CAW8": {
+    "name": "Bella Bella/Shearwater Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.150002,
+    "lon": -128.08299,
+    "elev": 0
+  },
+  "CAW9": {
+    "name": "Whaletown Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.108504,
+    "lon": -125.051001,
+    "elev": 0
+  },
+  "CAX3": {
+    "name": "Sechelt/Porpoise Bay Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.483,
+    "lon": -123.7577,
+    "elev": null
+  },
+  "CAX5": {
+    "name": "Likely Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.61669921875,
+    "lon": -121.5,
+    "elev": 3225
+  },
+  "CAX6": {
+    "name": "Ganges Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.8545,
+    "lon": -123.4969,
+    "elev": 0
+  },
+  "CAX7": {
+    "name": "Minstrel Island Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.608299,
+    "lon": -126.306038,
+    "elev": null
+  },
+  "CAX8": {
+    "name": "Smithers/Tyhee Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.716702,
+    "lon": -127.050005,
+    "elev": 1640
+  },
+  "CAY4": {
+    "name": "Hartley Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.416698,
+    "lon": -129.25,
+    "elev": 0
+  },
+  "CAY9": {
+    "name": "Winfield (Wood Lake) Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.049999,
+    "lon": -119.400002,
+    "elev": 1283
+  },
+  "CAZ3": {
+    "name": "Takla Landing Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.484,
+    "lon": -125.987,
+    "elev": 2260
+  },
+  "CAZ4": {
+    "name": "Quesnel (G.R. Baker Memorial Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.9826679166,
+    "lon": -122.500758469,
+    "elev": 1600
+  },
+  "CAZ5": {
+    "name": "Cache Creek-Ashcroft Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.775258,
+    "lon": -121.321314,
+    "elev": 2034,
+    "Freq": 123.2
+  },
+  "CAZ6": {
+    "name": "Fort St. James/Stuart River Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.419,
+    "lon": -124.271,
+    "elev": 2238
+  },
+  "CBA3": {
+    "name": "Kincolith Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.99,
+    "lon": -129.96,
+    "elev": 0
+  },
+  "CBA8": {
+    "name": "Beaverley Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.85559844970703,
+    "lon": -122.90799713134766,
+    "elev": 2420
+  },
+  "CBA9": {
+    "name": "Ospika Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.271002,
+    "lon": -124.063282,
+    "elev": 2300
+  },
+  "CBB4": {
+    "name": "Beddis Beach Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.79997,
+    "lon": -123.4236,
+    "elev": 717
+  },
+  "CBB5": {
+    "name": "Port Alice (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.425754,
+    "lon": -127.488595,
+    "elev": 50
+  },
+  "CBB6": {
+    "name": "Bowser Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.395182,
+    "lon": -129.945021,
+    "elev": 1452
+  },
+  "CBB9": {
+    "name": "Osoyoos Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.0372009277,
+    "lon": -119.488998413,
+    "elev": 1100,
+    "Freq": 123.2
+  },
+  "CBBC": {
+    "name": "Bella Bella (Campbell Island) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.185001,
+    "lon": -128.156994,
+    "elev": 141,
+    "Freq": 122.8
+  },
+  "CBC3": {
+    "name": "Alert Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.583302,
+    "lon": -126.932999,
+    "elev": null
+  },
+  "CBC4": {
+    "name": "Kamloops (Royal Inland Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.66903,
+    "lon": -120.333002,
+    "elev": 1349
+  },
+  "CBC7": {
+    "name": "Harbour (Public) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.286892,
+    "lon": -123.106112,
+    "elev": 2
+  },
+  "CBC8": {
+    "name": "Tofino General Hospital Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.1511,
+    "lon": -125.908997,
+    "elev": 50
+  },
+  "CBD2": {
+    "name": "Delta (North) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.1199607211,
+    "lon": -123.047267944,
+    "elev": 10
+  },
+  "CBD9": {
+    "name": "White Saddle Ranch Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.741853,
+    "lon": -124.738887,
+    "elev": 2925
+  },
+  "CBE2": {
+    "name": "Lionel P. Demers Memorial Airpark",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.285798,
+    "lon": -115.156923,
+    "elev": 2850
+  },
+  "CBE7": {
+    "name": "Alliford Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.214717,
+    "lon": -131.992082,
+    "elev": null
+  },
+  "CBE8": {
+    "name": "Moose Lake Lodge Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.075802,
+    "lon": -125.401001,
+    "elev": null
+  },
+  "CBE9": {
+    "name": "Whistler (Municipal) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.168377378100004,
+    "lon": -122.904754132,
+    "elev": 2116
+  },
+  "CBF4": {
+    "name": "Mission (Public Safety) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.132753634,
+    "lon": -122.343615219,
+    "elev": 85
+  },
+  "CBF5": {
+    "name": "Mayne Island (Medical Emergency) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.846656,
+    "lon": -123.284197,
+    "elev": 100
+  },
+  "CBF6": {
+    "name": "Seal Cove (Public) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.33000183105469,
+    "lon": -130.2779998779297,
+    "elev": 17
+  },
+  "CBF7": {
+    "name": "Victoria Harbour (Camel Point) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.418098,
+    "lon": -123.388,
+    "elev": 15
+  },
+  "CBF8": {
+    "name": "Muncho Lake/Mile 462 Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.009,
+    "lon": -125.775,
+    "elev": 2681
+  },
+  "CBF9": {
+    "name": "Mabel Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.6088981628418,
+    "lon": -118.73100280761719,
+    "elev": 1410
+  },
+  "CBG2": {
+    "name": "Green Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.42940139770508,
+    "lon": -121.20999908447266,
+    "elev": 3550
+  },
+  "CBG5": {
+    "name": "Nanaimo (Regional General Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.185749,
+    "lon": -123.971757,
+    "elev": 292
+  },
+  "CBG8": {
+    "name": "Prince George (Pacific Western Helicopters) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.8775233186,
+    "lon": -122.766669989,
+    "elev": 1940,
+    "Freq": 118.3
+  },
+  "CBG9": {
+    "name": "Courtenay Airpark Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.6814,
+    "lon": -124.981003,
+    "elev": null
+  },
+  "CBH2": {
+    "name": "Helmet Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.4258,
+    "lon": -120.797997,
+    "elev": 1930
+  },
+  "CBJ4": {
+    "name": "Echo Valley Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.241707,
+    "lon": -121.989785,
+    "elev": 3650,
+    "Freq": 123.2
+  },
+  "CBJ8": {
+    "name": "Fraser Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.0667,
+    "lon": -124.883003,
+    "elev": 2205
+  },
+  "CBJ9": {
+    "name": "San Juan Point (Coast Guard) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.531491,
+    "lon": -124.458178,
+    "elev": 25
+  },
+  "CBK4": {
+    "name": "Vancouver General Hospital Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.261947,
+    "lon": -123.124411,
+    "elev": 235
+  },
+  "CBK5": {
+    "name": "Port Alberni (West Coast General Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.248839168699995,
+    "lon": -124.783036038,
+    "elev": 272
+  },
+  "CBK6": {
+    "name": "Quesnel Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.513952,
+    "lon": -121.045938,
+    "elev": 2500
+  },
+  "CBK7": {
+    "name": "Mile 422 (Alaska Highway) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.84939956665039,
+    "lon": -125.23999786376953,
+    "elev": 2400
+  },
+  "CBK8": {
+    "name": "Victoria (Royal Jubilee Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.4342939918,
+    "lon": -123.325164914,
+    "elev": 50
+  },
+  "CBK9": {
+    "name": "Little Parker Island Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.8964,
+    "lon": -123.417999,
+    "elev": 22
+  },
+  "CBL3": {
+    "name": "Gordon Field",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.81669998168945,
+    "lon": -122.78299713134766,
+    "elev": 1625
+  },
+  "CBL6": {
+    "name": "Radium Hot Springs Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.627155,
+    "lon": -116.094981,
+    "elev": 2650
+  },
+  "CBL7": {
+    "name": "Cortes Island Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.05860137939453,
+    "lon": -124.98200225830078,
+    "elev": 230
+  },
+  "CBL9": {
+    "name": "Elkin Creek Guest Ranch Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.510453,
+    "lon": -123.806161,
+    "elev": 4080
+  },
+  "CBM6": {
+    "name": "Midway Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.0099983215332,
+    "lon": -118.79000091552734,
+    "elev": 1896
+  },
+  "CBM9": {
+    "name": "Port McNeill (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.581676562,
+    "lon": -127.066806257,
+    "elev": 150
+  },
+  "CBN4": {
+    "name": "Masset Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.009,
+    "lon": -132.15,
+    "elev": null
+  },
+  "CBN9": {
+    "name": "Tsay Keh Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.906101,
+    "lon": -124.964996,
+    "elev": 2280
+  },
+  "CBP3": {
+    "name": "Fernie (Elk Valley Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.512858,
+    "lon": -115.056179,
+    "elev": 3300
+  },
+  "CBP4": {
+    "name": "Sechelt (St. Mary's Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.476225,
+    "lon": -123.748554,
+    "elev": 179
+  },
+  "CBP5": {
+    "name": "Blackcomb Helicopters Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.685104,
+    "lon": -121.927246,
+    "elev": 700
+  },
+  "CBQ2": {
+    "name": "Fort Langley Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.16749954223633,
+    "lon": -122.55500030517578,
+    "elev": 30
+  },
+  "CBQ7": {
+    "name": "Kemess Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.97439956665039,
+    "lon": -126.74099731445312,
+    "elev": 4191
+  },
+  "CBQ8": {
+    "name": "Woodcock Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.06669998168945,
+    "lon": -128.23300170898438,
+    "elev": 537,
+    "Freq": 123.2
+  },
+  "CBQ9": {
+    "name": "Quennell Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.077497,
+    "lon": -123.831001,
+    "elev": 122
+  },
+  "CBR2": {
+    "name": "Kaslo Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.90359878540039,
+    "lon": -116.93499755859375,
+    "elev": 2354,
+    "Freq": 123.2
+  },
+  "CBR4": {
+    "name": "Clinton/Bleibler Ranch Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.266802,
+    "lon": -121.685772,
+    "elev": 3695
+  },
+  "CBR7": {
+    "name": "Tofino Lifeboat Station Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.15472,
+    "lon": -125.908077,
+    "elev": 10
+  },
+  "CBR8": {
+    "name": "Prince Rupert (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.305128,
+    "lon": -130.330183,
+    "elev": 279
+  },
+  "CBS4": {
+    "name": "Mule Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.773819,
+    "lon": -136.596161,
+    "elev": 2900
+  },
+  "CBS5": {
+    "name": "Port Hardy (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.72061,
+    "lon": -127.502614,
+    "elev": 85
+  },
+  "CBS8": {
+    "name": "Alberni Valley Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.321899,
+    "lon": -124.931,
+    "elev": 250,
+    "Freq": 123.0
+  },
+  "CBT3": {
+    "name": "Tsetzi Lake (Pan Phillips) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.970091,
+    "lon": -125.028674,
+    "elev": 3550
+  },
+  "CBT5": {
+    "name": "Golden (Golden & District General Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.297048,
+    "lon": -116.966994,
+    "elev": 2575
+  },
+  "CBT9": {
+    "name": "Sproat Lake Tanker Base Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.28981723689999,
+    "lon": -124.939095676,
+    "elev": 103
+  },
+  "CBU2": {
+    "name": "Eddontenajon / Iskut Village Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 57.847994155,
+    "lon": -129.983968735,
+    "elev": 3100,
+    "Freq": 123.2
+  },
+  "CBU4": {
+    "name": "Prince Rupert (Hydro) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.31169891357422,
+    "lon": -130.29400634765625,
+    "elev": 98
+  },
+  "CBU5": {
+    "name": "Terrace (Mills Memorial Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.5108709665,
+    "lon": -128.597647548,
+    "elev": 250
+  },
+  "CBV7": {
+    "name": "Valemount (Yellowhead Helicopters) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.866247,
+    "lon": -119.297577,
+    "elev": 2600
+  },
+  "CBV8": {
+    "name": "Comox (St. Joseph's Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.675075,
+    "lon": -124.941185,
+    "elev": 60
+  },
+  "CBW2": {
+    "name": "Kitimat Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.167758,
+    "lon": -128.578663,
+    "elev": 250
+  },
+  "CBW3": {
+    "name": "Fort Grahame Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.52138778769999,
+    "lon": -124.470291138,
+    "elev": 2230
+  },
+  "CBW4": {
+    "name": "Bob Quinn Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.966702,
+    "lon": -130.25,
+    "elev": 2000
+  },
+  "CBW7": {
+    "name": "Victoria (General Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.46796,
+    "lon": -123.43241,
+    "elev": 55
+  },
+  "CBW9": {
+    "name": "Madrona Bay Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.855801,
+    "lon": -123.486,
+    "elev": 35
+  },
+  "CBX7": {
+    "name": "Tumbler Ridge Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.025001525879,
+    "lon": -120.93499755859,
+    "elev": 3075,
+    "Freq": 123.2
+  },
+  "CBY5": {
+    "name": "Seal Cove (Coast Guard) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.331459,
+    "lon": -130.27684,
+    "elev": 17
+  },
+  "CBY6": {
+    "name": "Green Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.421902,
+    "lon": -121.213997,
+    "elev": 3507
+  },
+  "CBZ2": {
+    "name": "Kemano Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.562531,
+    "lon": -127.94858,
+    "elev": 160
+  },
+  "CBZ7": {
+    "name": "Victoria Harbour (Shoal Point) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.423208,
+    "lon": -123.387526,
+    "elev": 10
+  },
+  "CBZ9": {
+    "name": "Fraser Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.014454,
+    "lon": -124.771354,
+    "elev": 2690,
+    "Freq": 122.8
+  },
+  "CCI9": {
+    "name": "Cortes Island (Hansen Airfield) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.020301818847656,
+    "lon": -124.98400115966797,
+    "elev": 164
+  },
+  "CCR6": {
+    "name": "Campbell River (E & B Heli) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.041349,
+    "lon": -125.26857,
+    "elev": 7
+  },
+  "CCS6": {
+    "name": "Smit Field",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.666938,
+    "lon": -125.097654,
+    "elev": 500
+  },
+  "CCT3": {
+    "name": "Castlegar (Tarrys Convention Centre) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.38610076904297,
+    "lon": -117.552001953125,
+    "elev": 1632
+  },
+  "CCX6": {
+    "name": "Comox Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.670601,
+    "lon": -124.932999,
+    "elev": 0
+  },
+  "CDC3": {
+    "name": "Flying L Ranch Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.819489,
+    "lon": -120.460281,
+    "elev": 2680
+  },
+  "CDC5": {
+    "name": "Dougall Campbell Field",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.010801,
+    "lon": -121.2107,
+    "elev": 3060
+  },
+  "CDH4": {
+    "name": "Cowichan District Hospital Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.7862,
+    "lon": -123.7214,
+    "elev": 132
+  },
+  "CDH5": {
+    "name": "Nanaimo Harbour Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.160814,
+    "lon": -123.923217,
+    "elev": 12
+  },
+  "CER9": {
+    "name": "Fort Nelson (Parker Lake) Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.825217,
+    "lon": -122.900345,
+    "elev": 1255
+  },
+  "CEY7": {
+    "name": "Fort St. John (Charlie Lake) Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.286026,
+    "lon": -120.965824,
+    "elev": 2266
+  },
+  "CFH2": {
+    "name": "Frontline Helicopters Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.964601,
+    "lon": -121.812201,
+    "elev": 2644
+  },
+  "CFJ7": {
+    "name": "Fort St. John (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.246700286865234,
+    "lon": -120.84200286865234,
+    "elev": 2304
+  },
+  "CFN8": {
+    "name": "Fort Nelson (Guardian) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.752201080322266,
+    "lon": -122.68699645996094,
+    "elev": 1292
+  },
+  "CFR6": {
+    "name": "Vancouver / Coquitlam Fire and Rescue Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.2916156136,
+    "lon": -122.792148292,
+    "elev": 180
+  },
+  "CGB4": {
+    "name": "Nanaimo/Gabriola Island (Health Clinic) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.178333,
+    "lon": -123.83533,
+    "elev": 341
+  },
+  "CGF4": {
+    "name": "Boundary Hospital Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.030615,
+    "lon": -118.469894,
+    "elev": 1747
+  },
+  "CGL5": {
+    "name": "Gun Lake Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.88970184326172,
+    "lon": -122.84700012207031,
+    "elev": 2950
+  },
+  "CGL6": {
+    "name": "Vancouver / Burnaby (Global BC) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.2546009761,
+    "lon": -122.935177088,
+    "elev": 262
+  },
+  "CGR2": {
+    "name": "Gold River (E & B Helicopters) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.7533097005,
+    "lon": -126.055626869,
+    "elev": 182,
+    "Freq": 123.2
+  },
+  "CGR4": {
+    "name": "The Ridge Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.7832,
+    "lon": -126.043701,
+    "elev": 478
+  },
+  "CHT4": {
+    "name": "Nelson (High Terrain Helicopters) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.486702,
+    "lon": -117.327201,
+    "elev": 1950
+  },
+  "CIV2": {
+    "name": "Invermere (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.507211,
+    "lon": -116.032813,
+    "elev": 2900
+  },
+  "CKA2": {
+    "name": "Heffley Creek Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.868973,
+    "lon": -120.274115,
+    "elev": null
+  },
+  "CKB3": {
+    "name": "Kootenay Boundary Regional Hospital Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.103583,
+    "lon": -117.700315,
+    "elev": 1526
+  },
+  "CKH9": {
+    "name": "Kelowna General Hospital Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.8743,
+    "lon": -119.4924,
+    "elev": 1180
+  },
+  "CLD3": {
+    "name": "Burns Lake (LD Air) Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.21,
+    "lon": -125.756901,
+    "elev": 2300
+  },
+  "CMBH": {
+    "name": "Mount Belcher Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.832801818847656,
+    "lon": -123.50499725341797,
+    "elev": 1000
+  },
+  "CMH6": {
+    "name": "Canadian Mountain Holidays Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.78836,
+    "lon": -119.256235,
+    "elev": 2711
+  },
+  "CML2": {
+    "name": "Quamichan Lake (Raven Field) Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.8119010925293,
+    "lon": -123.6510009765625,
+    "elev": 130
+  },
+  "CND7": {
+    "name": "Slocan Community Hospital Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.9841,
+    "lon": -117.3744,
+    "elev": 1769
+  },
+  "CNH9": {
+    "name": "Nanaimo (West Coast) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.184838,
+    "lon": -123.989171,
+    "elev": 200
+  },
+  "CNM6": {
+    "name": "Naramata Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.6029,
+    "lon": -119.578501,
+    "elev": 1856
+  },
+  "CNW9": {
+    "name": "New Westminster (Royal Columbian Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.226671,
+    "lon": -122.892291,
+    "elev": 124
+  },
+  "CPW8": {
+    "name": "Powell River (Hospital) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.851447,
+    "lon": -124.517455,
+    "elev": 300
+  },
+  "CPW9": {
+    "name": "Port Alberni Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.231899,
+    "lon": -124.815002,
+    "elev": null
+  },
+  "CR8A": {
+    "name": "Reef Hueston Helicopter Landing",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.823101,
+    "lon": -126.172228,
+    "elev": null
+  },
+  "CRC3": {
+    "name": "Ross Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.965502,
+    "lon": -119.2254,
+    "elev": 1257
+  },
+  "CRF2": {
+    "name": "Langley (Russell Farm) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.0110458923,
+    "lon": -122.672213316,
+    "elev": 250
+  },
+  "CRF6": {
+    "name": "Quamichan Lake (Raven Field) Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.8083,
+    "lon": -123.650001,
+    "elev": 100
+  },
+  "CRG2": {
+    "name": "Argus Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.9616,
+    "lon": -119.445801,
+    "elev": 1894
+  },
+  "CRHA": {
+    "name": "Streatham Reef Hueston Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.822569,
+    "lon": -126.172957,
+    "elev": null
+  },
+  "CSE7": {
+    "name": "Delta (SEI) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.129088,
+    "lon": -123.018395,
+    "elev": 37
+  },
+  "CSM7": {
+    "name": "Abbotsford (Sumas Mountain) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.105322,
+    "lon": -122.197441,
+    "elev": 1067
+  },
+  "CSP4": {
+    "name": "Sproat Lake Landing Water Aerodrome.",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.284,
+    "lon": -124.973,
+    "elev": 105
+  },
+  "CSR6": {
+    "name": "Sonora Resort Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.3817339685,
+    "lon": -125.157558918,
+    "elev": 46
+  },
+  "CSU6": {
+    "name": "Spout Lake Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.0075,
+    "lon": -121.445,
+    "elev": 3560
+  },
+  "CTK8": {
+    "name": "Abbotsford (Teck) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.126854,
+    "lon": -122.395003,
+    "elev": 165
+  },
+  "CVA3": {
+    "name": "Valhalla Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.867697,
+    "lon": -119.560701,
+    "elev": 1539
+  },
+  "CVS3": {
+    "name": "Surrey Memorial Hospital Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.176015,
+    "lon": -122.84372,
+    "elev": 245
+  },
+  "CVW2": {
+    "name": "Vernon/Wildlife Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.243599,
+    "lon": -119.344002,
+    "elev": 1122
+  },
+  "CWC2": {
+    "name": "Kelowna (Wildcat Helicopters) Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.867423,
+    "lon": -119.579229,
+    "elev": 1640
+  },
+  "CWCV": {
+    "name": "Nootka Lightstation Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.59225,
+    "lon": -126.616383,
+    "elev": 48
+  },
+  "CWFM": {
+    "name": "Chatham Point Light Station Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.333101,
+    "lon": -125.445263,
+    "elev": 75
+  },
+  "CWIF": {
+    "name": "Quatsino Light Station Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.441691,
+    "lon": -128.031474,
+    "elev": 35
+  },
+  "CWZM": {
+    "name": "Boat Bluff Lighthouse Helipad",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.643733,
+    "lon": -128.524586,
+    "elev": 44
+  },
+  "CYAL": {
+    "name": "Alert Bay Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.582199,
+    "lon": -126.916,
+    "elev": 240
+  },
+  "CYAZ": {
+    "name": "Tofino / Long Beach Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.079833,
+    "lon": -125.775583,
+    "elev": 80,
+    "Freq": 132.9
+  },
+  "CYB3": {
+    "name": "Nelson/Baylock Estate Heliport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.54472222,
+    "lon": -117.2605555,
+    "elev": 1830
+  },
+  "CYBD": {
+    "name": "Bella Coola Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.387501,
+    "lon": -126.596001,
+    "elev": 117,
+    "Freq": 122.8
+  },
+  "CYBL": {
+    "name": "Campbell River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.950802,
+    "lon": -125.271004,
+    "elev": 346,
+    "Freq": 122.0
+  },
+  "CYCD": {
+    "name": "Nanaimo Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.05497,
+    "lon": -123.869863,
+    "elev": 92,
+    "Freq": 133.95
+  },
+  "CYCG": {
+    "name": "Castlegar/West Kootenay Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.296398,
+    "lon": -117.632004,
+    "elev": 1624,
+    "Freq": 122.1
+  },
+  "CYCP": {
+    "name": "Blue River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.11669921875,
+    "lon": -119.28299713134766,
+    "elev": 2240,
+    "Freq": 123.2
+  },
+  "CYCQ": {
+    "name": "Chetwynd Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.687198638916016,
+    "lon": -121.62699890136719,
+    "elev": 2000,
+    "Freq": 123.2
+  },
+  "CYCW": {
+    "name": "Chilliwack Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.153157,
+    "lon": -121.939309,
+    "elev": 32,
+    "Freq": 122.7
+  },
+  "CYCZ": {
+    "name": "Fairmont Hot Springs Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.331052,
+    "lon": -115.873739,
+    "elev": 2661,
+    "Freq": 123.2
+  },
+  "CYDC": {
+    "name": "Princeton Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.468102,
+    "lon": -120.511002,
+    "elev": 2298,
+    "Freq": 123.2
+  },
+  "CYDL": {
+    "name": "Dease Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.422199,
+    "lon": -130.031998,
+    "elev": 2600,
+    "Freq": 123.2
+  },
+  "CYDQ": {
+    "name": "Dawson Creek Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.741245,
+    "lon": -120.183263,
+    "elev": 2148,
+    "Freq": 122.2
+  },
+  "CYGB": {
+    "name": "Texada Gillies Bay Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.694341,
+    "lon": -124.518099,
+    "elev": 326,
+    "Freq": 122.7
+  },
+  "CYGE": {
+    "name": "Golden Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.299196,
+    "lon": -116.982002,
+    "elev": 2575,
+    "Freq": 122.8
+  },
+  "CYHC": {
+    "name": "Vancouver Harbour Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.291265,
+    "lon": -123.11717,
+    "elev": null
+  },
+  "CYHE": {
+    "name": "Hope Airport / FVRD Regional Airpark",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.368865,
+    "lon": -121.49495,
+    "elev": 128,
+    "Freq": 123.3
+  },
+  "CYJM": {
+    "name": "Fort St James Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.39720153808594,
+    "lon": -124.26300048828125,
+    "elev": 2364,
+    "Freq": 123.2
+  },
+  "CYJQ": {
+    "name": "Denny Island Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.136474,
+    "lon": -128.056182,
+    "elev": 162
+  },
+  "CYKA": {
+    "name": "Kamloops John Moose Fulton Field Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.703038,
+    "lon": -120.448641,
+    "elev": 1133,
+    "Freq": 121.9
+  },
+  "CYKT": {
+    "name": "Tranquille Valley Airfield",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.859547,
+    "lon": -120.671132,
+    "elev": null
+  },
+  "CYLI": {
+    "name": "Lillooet Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.674702,
+    "lon": -121.893997,
+    "elev": 1320,
+    "Freq": 123.2
+  },
+  "CYLW": {
+    "name": "Kelowna International Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.9561,
+    "lon": -119.377998,
+    "elev": 1421,
+    "Freq": 119.6
+  },
+  "CYNH": {
+    "name": "Hudson's Hope Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.035142,
+    "lon": -121.978326,
+    "elev": 2220,
+    "Freq": 123.2
+  },
+  "CYNJ": {
+    "name": "Langley Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.1008,
+    "lon": -122.630997,
+    "elev": 34,
+    "Freq": 119.0
+  },
+  "CYPK": {
+    "name": "Pitt Meadows Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.216099,
+    "lon": -122.709999,
+    "elev": 11,
+    "Freq": 126.3
+  },
+  "CYPR": {
+    "name": "Prince Rupert Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.286098480199996,
+    "lon": -130.445007324,
+    "elev": 116,
+    "Freq": 122.5
+  },
+  "CYPS": {
+    "name": "Pemberton Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.302502,
+    "lon": -122.737999,
+    "elev": 670,
+    "Freq": 123.2
+  },
+  "CYPU": {
+    "name": "Puntzi Mountain Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.11280059814453,
+    "lon": -124.1449966430664,
+    "elev": 2985,
+    "Freq": 126.7
+  },
+  "CYPW": {
+    "name": "Powell River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.83420181274414,
+    "lon": -124.5,
+    "elev": 425,
+    "Freq": 123.0
+  },
+  "CYPZ": {
+    "name": "Burns Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.3764,
+    "lon": -125.950996,
+    "elev": 2343,
+    "Freq": 122.7
+  },
+  "CYQQ": {
+    "name": "Comox Valley Airport / CFB Comox",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.7108,
+    "lon": -124.887001,
+    "elev": 84,
+    "Freq": 126.2
+  },
+  "CYQZ": {
+    "name": "Quesnel Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.026100158691406,
+    "lon": -122.51000213623047,
+    "elev": 1789,
+    "Freq": 122.2
+  },
+  "CYRV": {
+    "name": "Revelstoke Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.962245,
+    "lon": -118.184258,
+    "elev": 1459,
+    "Freq": 122.8
+  },
+  "CYSE": {
+    "name": "Squamish Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.7817001343,
+    "lon": -123.162002563,
+    "elev": 171,
+    "Freq": 122.8
+  },
+  "CYSQ": {
+    "name": "Atlin Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 59.57833,
+    "lon": -133.668938,
+    "elev": 2348
+  },
+  "CYSW": {
+    "name": "Sparwood Elk Valley Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.834273,
+    "lon": -114.878653,
+    "elev": 3800,
+    "Freq": 123.2
+  },
+  "CYVK": {
+    "name": "Vernon Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.246163,
+    "lon": -119.330963,
+    "elev": 1140,
+    "Freq": 122.8
+  },
+  "CYVR": {
+    "name": "Vancouver International Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.193901062,
+    "lon": -123.183998108,
+    "elev": 14,
+    "Freq": 118.7
+  },
+  "CYWH": {
+    "name": "Victoria Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.423782,
+    "lon": -123.37198,
+    "elev": null
+  },
+  "CYWL": {
+    "name": "Williams Lake Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.1831016541,
+    "lon": -122.054000854,
+    "elev": 3085,
+    "Freq": 122.3
+  },
+  "CYXC": {
+    "name": "Cranbrook/Canadian Rockies International Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.610801696777,
+    "lon": -115.78199768066,
+    "elev": 3082,
+    "Freq": 122.3
+  },
+  "CYXJ": {
+    "name": "Fort St John / North Peace Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 56.238098,
+    "lon": -120.739998,
+    "elev": 2280,
+    "Freq": 118.5
+  },
+  "CYXS": {
+    "name": "Prince George Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.884311,
+    "lon": -122.666554,
+    "elev": 2267,
+    "Freq": 118.3
+  },
+  "CYXT": {
+    "name": "Northwest Regional Airport Terrace-Kitimat",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.468498,
+    "lon": -128.576009,
+    "elev": 713,
+    "Freq": 122.0
+  },
+  "CYXX": {
+    "name": "Abbotsford International Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.025299,
+    "lon": -122.361,
+    "elev": 195,
+    "Freq": 119.4
+  },
+  "CYYD": {
+    "name": "Smithers Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.82469940185547,
+    "lon": -127.18299865722656,
+    "elev": 1712,
+    "Freq": 122.3
+  },
+  "CYYE": {
+    "name": "Fort Nelson Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 58.8363990784,
+    "lon": -122.597000122,
+    "elev": 1253,
+    "Freq": 125.65
+  },
+  "CYYF": {
+    "name": "Penticton Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.46310043334961,
+    "lon": -119.60199737548828,
+    "elev": 1129,
+    "Freq": 118.5
+  },
+  "CYYJ": {
+    "name": "Victoria International Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.647201,
+    "lon": -123.427792,
+    "elev": 63,
+    "Freq": 119.1
+  },
+  "CYZP": {
+    "name": "Sandspit Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 53.25429916379999,
+    "lon": -131.813995361,
+    "elev": 21,
+    "Freq": 122.3
+  },
+  "CYZT": {
+    "name": "Port Hardy Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.680599212646484,
+    "lon": -127.36699676513672,
+    "elev": 71,
+    "Freq": 122.2
+  },
+  "CYZY": {
+    "name": "Mackenzie Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.297786,
+    "lon": -123.133907,
+    "elev": 2264,
+    "Freq": 126.7
+  },
+  "CZAM": {
+    "name": "Shuswap Regional Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.682802,
+    "lon": -119.228996,
+    "elev": 1751,
+    "Freq": 122.9
+  },
+  "CZBB": {
+    "name": "Boundary Bay Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.0742,
+    "lon": -123.012001,
+    "elev": 6,
+    "Freq": 118.1
+  },
+  "CZGF": {
+    "name": "Grand Forks Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.015598,
+    "lon": -118.431,
+    "elev": 1720,
+    "Freq": 123.2
+  },
+  "CZML": {
+    "name": "South Cariboo Region / 108 Mile Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.736099243199995,
+    "lon": -121.333000183,
+    "elev": 3126,
+    "Freq": 134.0
+  },
+  "CZMT": {
+    "name": "Masset Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.0275,
+    "lon": -132.125,
+    "elev": 25,
+    "Freq": 122.7
+  },
+  "CZNL": {
+    "name": "Nelson Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.4942016602,
+    "lon": -117.301002502,
+    "elev": 1755,
+    "Freq": 123.2
+  },
+  "CZST": {
+    "name": "Stewart Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 55.935410448,
+    "lon": -129.982434511,
+    "elev": 24,
+    "Freq": 123.2
+  },
+  "CZSW": {
+    "name": "Prince Rupert/Seal Cove Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 54.333302,
+    "lon": -130.283005,
+    "elev": null
+  },
+  "KCA2": {
+    "name": "The Hill Airstrip",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.218848,
+    "lon": -123.449538,
+    "elev": null
+  },
+  "SYF": {
+    "name": "Silva Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.151,
+    "lon": -123.698,
+    "elev": null
+  },
+  "XBB": {
+    "name": "Blubber Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 49.793958,
+    "lon": -124.621064,
+    "elev": 0
+  },
+  "YAJ": {
+    "name": "Lyall Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.795274,
+    "lon": -123.181801,
+    "elev": null
+  },
+  "YAQ": {
+    "name": "Maple Bay Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.8167,
+    "lon": -123.6084,
+    "elev": null
+  },
+  "YBH": {
+    "name": "Bull Harbour Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.9179,
+    "lon": -127.9372,
+    "elev": 0
+  },
+  "YBQ": {
+    "name": "Telegraph Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 48.97,
+    "lon": -123.664,
+    "elev": null
+  },
+  "YCF": {
+    "name": "Cortes Bay Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.063,
+    "lon": -124.930002,
+    "elev": null
+  },
+  "YGE": {
+    "name": "Gorge Harbour Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.0994,
+    "lon": -125.0235,
+    "elev": 0
+  },
+  "YGN": {
+    "name": "Greenway Sound Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.839,
+    "lon": -126.775,
+    "elev": null
+  },
+  "YKT": {
+    "name": "Klemtu Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.6076345452,
+    "lon": -128.521757126,
+    "elev": 0
+  },
+  "YQJ": {
+    "name": "April Point Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.065,
+    "lon": -125.235,
+    "elev": null
+  },
+  "YRC": {
+    "name": "Refuge Cove Seaplane Base",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 50.1234,
+    "lon": -124.843,
+    "elev": 0
+  },
+  "YRD": {
+    "name": "Dean River Airport",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 52.82371,
+    "lon": -126.964957,
+    "elev": 62
+  },
+  "ZNU": {
+    "name": "Namu Water Aerodrome",
+    "regions": [
+      "ALL"
+    ],
+    "lat": 51.862825,
+    "lon": -127.869357,
+    "elev": 0
+  }
+}


### PR DESCRIPTION
## Summary
- gather BC airport data from open datasets
- include frequency info when available
- add `bc_airports.json` listing all airports in British Columbia

## Testing
- `python3 - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_687ea70563788321ab28d576a6f64713