### PR TITLE
Standardize names with (A)

### DIFF
--- a/bc_airports.json
+++ b/bc_airports.json
@@ -156,7 +156,7 @@
     "elev": 2450
   },
   "CAK3": {
-    "name": "Delta Heritage Air Park",
+    "name": "Delta Heritage (A)",
     "regions": [
       "ALL"
     ],
@@ -426,7 +426,7 @@
     "elev": 50
   },
   "CBB6": {
-    "name": "Bowser Aerodrome",
+    "name": "Bowser (A)",
     "regions": [
       "ALL"
     ],
@@ -801,7 +801,7 @@
     "Freq": 123.2
   },
   "CBR4": {
-    "name": "Clinton/Bleibler Ranch Aerodrome",
+    "name": "Clinton/Bleibler Ranch (A)",
     "regions": [
       "ALL"
     ],


### PR DESCRIPTION
## Summary
- replace `Air Park` with `(A)`
- replace `Aerodrome` with `(A)`

## Testing
- `grep -n -i "air park" -n bc_airports.json`
- `grep -n -i "Aerodrome" -n bc_airports.json`


------
https://chatgpt.com/codex/tasks/task_e_687f65a29f288321b425e757bb078fc8