### PR TITLE
Add vancouver region to waypoints

### DIFF
--- a/data.json
+++ b/data.json
@@ -48,7 +48,8 @@
       "regions": [
         "Vancouver",
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.0362,
       "lon": -122.314,
@@ -58,7 +59,8 @@
       "name": "Kelowna (Alpine) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.8639,
       "lon": -119.5685,
@@ -80,7 +82,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.1225,
       "lon": -120.7454,
@@ -102,7 +105,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.5264,
       "lon": -124.164,
@@ -113,7 +117,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.6258,
       "lon": -124.1445,
@@ -123,7 +128,8 @@
       "name": "Courtenay (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.6792,
       "lon": -124.9806,
@@ -178,7 +184,8 @@
       "name": "Delta Heritage (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.0774,
       "lon": -122.941,
@@ -189,7 +196,8 @@
       "name": "Vancouver Children & Women's",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2438,
       "lon": -123.1271,
@@ -210,7 +218,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.1655,
       "lon": -120.1713,
@@ -221,7 +230,8 @@
       "name": "Ganges (Lady Minto hosp)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.8625,
       "lon": -123.5087,
@@ -231,7 +241,8 @@
       "name": "Duncan (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.7545,
       "lon": -123.7097,
@@ -254,7 +265,8 @@
       "name": "Sechelt-Gibsons (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.4606,
       "lon": -123.719,
@@ -275,7 +287,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.9549,
       "lon": -122.14,
@@ -307,7 +320,8 @@
       "name": "Aerosmith Heli Service (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.3074,
       "lon": -124.4133,
@@ -317,7 +331,8 @@
       "name": "Qualicum Beach (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.3375,
       "lon": -124.3931,
@@ -327,7 +342,8 @@
     "CAT5": {
       "name": "Port McNeill (A)",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 50.5735,
       "lon": -127.0277,
@@ -337,7 +353,8 @@
       "name": "Campbell River hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.0086,
       "lon": -125.2428,
@@ -347,7 +364,8 @@
       "name": "Oliver (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1733,
       "lon": -119.551,
@@ -370,7 +388,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.6425,
       "lon": -121.307,
@@ -392,7 +411,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.7954,
       "lon": -123.5816,
@@ -403,7 +423,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.1203,
       "lon": -122.9547,
@@ -436,7 +457,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.7753,
       "lon": -121.3213,
@@ -467,7 +489,8 @@
       "name": "Beddis Beach Helipad",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.8,
       "lon": -123.4236,
@@ -496,7 +519,8 @@
       "name": "Osoyoos (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.0372,
       "lon": -119.489,
@@ -520,7 +544,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.669,
       "lon": -120.333,
@@ -530,7 +555,8 @@
       "name": "Harbour (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2869,
       "lon": -123.1061,
@@ -539,7 +565,8 @@
     "CBC8": {
       "name": "Tofino General hosp",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 49.1511,
       "lon": -125.909,
@@ -549,7 +576,8 @@
       "name": "Delta (North) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.12,
       "lon": -123.0473,
@@ -560,7 +588,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.7419,
       "lon": -124.7389,
@@ -580,7 +609,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.1684,
       "lon": -122.9048,
@@ -590,7 +620,8 @@
       "name": "Mission (Public Safety) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1328,
       "lon": -122.3436,
@@ -600,7 +631,8 @@
       "name": "Mayne Island (Medical Emergency) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.8467,
       "lon": -123.2842,
@@ -620,7 +652,8 @@
       "name": "Victoria Harbour (Camel Point) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.4181,
       "lon": -123.388,
@@ -642,7 +675,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.4294,
       "lon": -121.21,
@@ -652,7 +686,8 @@
       "name": "Nanaimo hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1857,
       "lon": -123.9718,
@@ -672,7 +707,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.2417,
       "lon": -121.9898,
@@ -682,7 +718,8 @@
     "CBJ9": {
       "name": "San Juan Point (Coast Guard) (H)",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 48.5315,
       "lon": -124.4582,
@@ -692,7 +729,8 @@
       "name": "Vancouver General hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2619,
       "lon": -123.1244,
@@ -702,7 +740,8 @@
       "name": "Port Alberni hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2488,
       "lon": -124.783,
@@ -732,7 +771,8 @@
       "name": "Victoria (Royal Jubilee hosp)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.4343,
       "lon": -123.3252,
@@ -742,7 +782,8 @@
       "name": "Little Parker Island (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.8964,
       "lon": -123.418,
@@ -772,7 +813,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.0586,
       "lon": -124.982,
@@ -783,7 +825,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.5105,
       "lon": -123.8062,
@@ -793,7 +836,8 @@
       "name": "Midway (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.01,
       "lon": -118.79,
@@ -802,7 +846,8 @@
     "CBM9": {
       "name": "Port McNeill hosp",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 50.5817,
       "lon": -127.0668,
@@ -831,7 +876,8 @@
       "name": "Sechelt hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.4762,
       "lon": -123.7486,
@@ -842,7 +888,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.6851,
       "lon": -121.9272,
@@ -852,7 +899,8 @@
       "name": "Fort Langley (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1675,
       "lon": -122.555,
@@ -896,7 +944,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.2668,
       "lon": -121.6858,
@@ -905,7 +954,8 @@
     "CBR7": {
       "name": "Tofino Lifeboat Station Helipad",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 49.1547,
       "lon": -125.9081,
@@ -943,7 +993,8 @@
       "name": "Alberni Valley Regional (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.3219,
       "lon": -124.931,
@@ -974,7 +1025,8 @@
       "name": "Sproat Lake Tanker Base (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2898,
       "lon": -124.9391,
@@ -1026,7 +1078,8 @@
       "name": "Comox hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.6751,
       "lon": -124.9412,
@@ -1067,7 +1120,8 @@
       "name": "Victoria hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.468,
       "lon": -123.4324,
@@ -1077,7 +1131,8 @@
       "name": "Madrona Bay (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.8558,
       "lon": -123.486,
@@ -1119,7 +1174,8 @@
       "name": "Victoria Harbour (Shoal Point) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.4232,
       "lon": -123.3875,
@@ -1141,7 +1197,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.0203,
       "lon": -124.984,
@@ -1152,7 +1209,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.0413,
       "lon": -125.2686,
@@ -1162,7 +1220,8 @@
       "name": "Smit Field",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.6669,
       "lon": -125.0977,
@@ -1203,7 +1262,8 @@
       "name": "Cowichan District hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.7862,
       "lon": -123.7214,
@@ -1213,7 +1273,8 @@
       "name": "Nanaimo Harbour (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1608,
       "lon": -123.9232,
@@ -1224,7 +1285,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.9646,
       "lon": -121.8122,
@@ -1253,7 +1315,8 @@
       "name": "Vancouver / Coquitlam Fire and Rescue (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2916,
       "lon": -122.7921,
@@ -1263,7 +1326,8 @@
       "name": "Nanaimo/Gabriola Island (Health Clinic)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1783,
       "lon": -123.8353,
@@ -1284,7 +1348,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.8897,
       "lon": -122.847,
@@ -1294,7 +1359,8 @@
       "name": "Vancouver / Burnaby (Global BC) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2546,
       "lon": -122.9352,
@@ -1303,7 +1369,8 @@
     "CGR2": {
       "name": "Gold River (E & B Helicopters) (H)",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 49.7533,
       "lon": -126.0556,
@@ -1313,7 +1380,8 @@
     "CGR4": {
       "name": "The Ridge (H)",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 49.7832,
       "lon": -126.0437,
@@ -1344,7 +1412,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.869,
       "lon": -120.2741,
@@ -1364,7 +1433,8 @@
       "name": "Kelowna General hosp",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.8743,
       "lon": -119.4924,
@@ -1374,7 +1444,8 @@
       "name": "Mount Belcher (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.8328,
       "lon": -123.505,
@@ -1395,7 +1466,8 @@
       "name": "Quamichan Lake (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.8119,
       "lon": -123.651,
@@ -1415,7 +1487,8 @@
       "name": "Nanaimo (West Coast) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1848,
       "lon": -123.9892,
@@ -1425,7 +1498,8 @@
       "name": "Naramata (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.6029,
       "lon": -119.5785,
@@ -1435,7 +1509,8 @@
       "name": "New Westminster hosp (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2267,
       "lon": -122.8923,
@@ -1445,7 +1520,8 @@
       "name": "Powell River hosp (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.8514,
       "lon": -124.5175,
@@ -1477,7 +1553,8 @@
       "name": "Langley (Russell Farm) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.011,
       "lon": -122.6722,
@@ -1487,7 +1564,8 @@
       "name": "Argus (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.9616,
       "lon": -119.4458,
@@ -1508,7 +1586,8 @@
       "name": "Delta (SEI) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1291,
       "lon": -123.0184,
@@ -1519,7 +1598,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.3817,
       "lon": -125.1576,
@@ -1529,7 +1609,8 @@
       "name": "Abbotsford (Teck) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1269,
       "lon": -122.395,
@@ -1539,7 +1620,8 @@
       "name": "Valhalla (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.8677,
       "lon": -119.5607,
@@ -1549,7 +1631,8 @@
       "name": "Surrey Memorial hosp (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.176,
       "lon": -122.8437,
@@ -1559,7 +1642,8 @@
       "name": "Kelowna (Wildcat Helicopters) (H)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.8674,
       "lon": -119.5792,
@@ -1568,7 +1652,8 @@
     "CWCV": {
       "name": "Nootka Lightstation Helipad",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 49.5922,
       "lon": -126.6164,
@@ -1579,7 +1664,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.3331,
       "lon": -125.4453,
@@ -1608,7 +1694,8 @@
     "CYAL": {
       "name": "Alert Bay (A)",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 50.5822,
       "lon": -126.916,
@@ -1617,7 +1704,8 @@
     "CYAZ": {
       "name": "Tofino / Long Beach (A)",
       "regions": [
-        "ALL"
+        "ALL",
+        "vancouver"
       ],
       "lat": 49.0798,
       "lon": -125.7756,
@@ -1650,7 +1738,8 @@
       "name": "Campbell River (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.9508,
       "lon": -125.271,
@@ -1661,7 +1750,8 @@
       "name": "Nanaimo (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.055,
       "lon": -123.8699,
@@ -1706,7 +1796,8 @@
       "name": "Chilliwack (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1532,
       "lon": -121.9393,
@@ -1728,7 +1819,8 @@
       "name": "Princeton (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.4681,
       "lon": -120.511,
@@ -1760,7 +1852,8 @@
       "name": "Texada Gillies Bay (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.6943,
       "lon": -124.5181,
@@ -1782,7 +1875,8 @@
       "name": "Hope (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.3689,
       "lon": -121.495,
@@ -1816,7 +1910,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.703,
       "lon": -120.4486,
@@ -1828,7 +1923,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.8595,
       "lon": -120.6711,
@@ -1839,7 +1935,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.6747,
       "lon": -121.894,
@@ -1850,7 +1947,8 @@
       "name": "Kelowna INT (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.9561,
       "lon": -119.378,
@@ -1872,7 +1970,8 @@
       "name": "Langley (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1008,
       "lon": -122.631,
@@ -1883,7 +1982,8 @@
       "name": "Pitt Meadows (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.2161,
       "lon": -122.71,
@@ -1906,7 +2006,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.3025,
       "lon": -122.738,
@@ -1918,7 +2019,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 52.1128,
       "lon": -124.145,
@@ -1929,7 +2031,8 @@
       "name": "Powell River (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.8342,
       "lon": -124.5,
@@ -1952,7 +2055,8 @@
       "name": "Comox Valley (A) / CFB Comox",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.7108,
       "lon": -124.887,
@@ -1988,7 +2092,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.7817,
       "lon": -123.162,
@@ -2018,7 +2123,8 @@
       "name": "Vernon Regional (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.2462,
       "lon": -119.331,
@@ -2029,7 +2135,8 @@
       "name": "Vancouver INT (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.1939,
       "lon": -123.184,
@@ -2096,7 +2203,8 @@
       "name": "Abbotsford INT (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.0253,
       "lon": -122.361,
@@ -2129,7 +2237,8 @@
       "name": "Penticton (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.4631,
       "lon": -119.602,
@@ -2140,7 +2249,8 @@
       "name": "Victoria INT (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 48.6472,
       "lon": -123.4278,
@@ -2184,7 +2294,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 50.6828,
       "lon": -119.229,
@@ -2195,7 +2306,8 @@
       "name": "Boundary Bay (A)",
       "regions": [
         "ALL",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 49.0742,
       "lon": -123.012,
@@ -2218,7 +2330,8 @@
       "regions": [
         "ALL",
         "prince george",
-        "kamloops"
+        "kamloops",
+        "vancouver"
       ],
       "lat": 51.7361,
       "lon": -121.333,


### PR DESCRIPTION
## Summary
- update `data.json` so any waypoint within 180 nm of CYVR includes the new region label `vancouver`

## Testing
- `python3 -m json.tool data.json`

------
https://chatgpt.com/codex/tasks/task_e_687faf47abf08321be207b8673761f7b